### PR TITLE
chore: scaffold: add Next.js 14 + TypeScript + Tailwind base

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  // Root ESLint config enforcing Next.js best practices and Prettier formatting
+  "root": true,
+  "extends": ["next/core-web-vitals", "prettier"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore dependencies and build output
+node_modules
+apps/web/.next
+apps/web/dist
+pnpm-lock.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  // Prettier rules ensure consistent code style
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,16 @@
+// Root layout applies global styles and the default pastel theme
+import '../styles/globals.css';
+import { pastelTheme } from '../lib/theme';
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'StanPi'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" style={{ backgroundColor: pastelTheme.background, color: pastelTheme.foreground }}>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,9 @@
+// Simple placeholder page for the market table
+export default function Page() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">StanPi</h1>
+      {/* Content will be filled in future PRs */}
+    </main>
+  );
+}

--- a/apps/web/lib/theme.ts
+++ b/apps/web/lib/theme.ts
@@ -1,0 +1,14 @@
+// Pastel color tokens used across the app
+export const pastelTheme = {
+  background: '#f3f4f6', // light gray background similar to Microsoft 365
+  foreground: '#1f2937', // dark gray text color for good contrast
+  accent: '#93c5fd' // soft blue accent color
+};
+
+// Helper that writes the theme values to CSS variables on the root element
+export function applyTheme(theme: typeof pastelTheme): void {
+  const root = document.documentElement;
+  root.style.setProperty('--bg', theme.background);
+  root.style.setProperty('--fg', theme.foreground);
+  root.style.setProperty('--accent', theme.accent);
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+// Next.js configuration enabling React strict mode and SWC minification
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true
+};
+
+export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "web",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.0.0",
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwind-merge": "^1.14.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.5.7",
+    "@types/react": "^18.2.24",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.3",
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "^5.2.2"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,8 @@
+/** @type {import('postcss-load-config').Config} */
+// PostCSS config hooking Tailwind and autoprefixer into Next.js build pipeline
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -1,0 +1,5 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Global styles and Tailwind layer directives */

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,17 @@
+import type { Config } from 'tailwindcss';
+
+// Tailwind scans these files to generate utility classes and includes shadcn/ui defaults
+const config: Config = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './styles/**/*.{css}',
+    '../../packages/ui/src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: [require('tailwindcss-animate')]
+};
+
+export default config;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  // TypeScript configuration for the Next.js app
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "stanpi",
+  "private": true,
+  "packageManager": "pnpm@8.15.1",
+  "scripts": {
+    "dev": "pnpm --filter web dev",
+    "build": "pnpm --filter web build",
+    "start": "pnpm --filter web start",
+    "lint": "pnpm --filter web lint",
+    "typecheck": "pnpm --filter web typecheck"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.0.4",
+    "eslint-config-prettier": "^9.0.0",
+    "prettier": "^3.1.1",
+    "typescript": "^5.2.2"
+  }
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@stanpi/ui",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "clsx": "^2.0.0",
+    "tailwind-merge": "^1.14.0"
+  },
+  "exports": {
+    ".": {
+      "import": "./src/index.ts"
+    }
+  }
+}

--- a/packages/ui/src/cn.ts
+++ b/packages/ui/src/cn.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+// Combines class names using clsx and resolves Tailwind conflicts with tailwind-merge
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,2 @@
+// Re-export utilities from the UI package for external consumption
+export * from './cn';

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./apps/web" }
+  ]
+}


### PR DESCRIPTION
## Summary
- set up pnpm monorepo with Next.js app
- configure Tailwind and shadcn/ui helper
- add base pastel theme and linting presets

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm dev` (verify site loads on http://localhost:3000)


------
https://chatgpt.com/codex/tasks/task_e_6895dad76e24832d871a327c5413ac3d