### PR TITLE
feat(web): market table with search/sort + sparklines

### DIFF
--- a/apps/web/app/asset/[id]/page.tsx
+++ b/apps/web/app/asset/[id]/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+interface AssetPageProps {
+  params: { id: string };
+}
+
+export default function AssetPage({ params }: AssetPageProps) {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-semibold">{params.id}</h1>
+      <p className="mt-2">
+        <Link href="/" className="text-blue-600 underline">
+          Back to markets
+        </Link>
+      </p>
+      {/* TODO: will render TradingView chart in a later PR */}
+    </main>
+  );
+}

--- a/apps/web/app/components/MarketTable.tsx
+++ b/apps/web/app/components/MarketTable.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { Asset } from '@stanpi/data';
+import Sparkline from './Sparkline';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+// Column keys that support sorting. All current keys map to numeric Asset fields,
+// but the sort routine below also guards against future string additions.
+const sortKeys = ['rank', 'price', 'change24h', 'volume24h', 'marketCap'] as const;
+type SortKey = (typeof sortKeys)[number];
+
+// Narrow unknown values to numbers at runtime
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number';
+}
+
+interface MarketTableProps {
+  assets: Asset[];
+}
+
+export default function MarketTable({ assets }: MarketTableProps) {
+  const router = useRouter();
+  const [query, setQuery] = useState('');
+  const [debounced, setDebounced] = useState('');
+  const [sortKey, setSortKey] = useState<SortKey>('rank');
+  const [ascending, setAscending] = useState(true);
+
+  // Debounce the search input to avoid filtering on every keystroke
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(query), 250);
+    return () => clearTimeout(id);
+  }, [query]);
+
+  // Filter and sort the asset list whenever dependencies change
+  const list = useMemo(() => {
+    const q = debounced.toLowerCase();
+    const filtered = assets.filter(
+      (a) => a.name.toLowerCase().includes(q) || a.symbol.toLowerCase().includes(q)
+    );
+    const sorted = [...filtered].sort((a, b) => {
+      const av = a[sortKey];
+      const bv = b[sortKey];
+      // Use numeric subtraction when both values are numbers; otherwise fall back
+      // to string comparison. This prevents NaN results if a string slips in.
+      const res =
+        isNumber(av) && isNumber(bv)
+          ? av - bv
+          : String(av).localeCompare(String(bv));
+      return ascending ? res : -res;
+    });
+    return sorted;
+  }, [assets, debounced, sortKey, ascending]);
+
+  // Toggle sort direction or switch column
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setAscending(!ascending);
+    } else {
+      setSortKey(key);
+      setAscending(true);
+    }
+  }
+
+  // Helper to render arrow indicator
+  function sortIndicator(key: SortKey) {
+    if (sortKey !== key) return null;
+    return ascending ? '▲' : '▼';
+  }
+
+  return (
+    <Card className="overflow-x-auto">
+      <div className="p-4">
+        <Input
+          placeholder="Search assets..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="mb-4 max-w-xs"
+        />
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>
+                <Button variant="ghost" onClick={() => handleSort('rank')}>
+                  Rank {sortIndicator('rank')}
+                </Button>
+              </TableHead>
+              <TableHead>Name</TableHead>
+              <TableHead>
+                <Button variant="ghost" onClick={() => handleSort('price')}>
+                  Price {sortIndicator('price')}
+                </Button>
+              </TableHead>
+              <TableHead>
+                <Button variant="ghost" onClick={() => handleSort('change24h')}>
+                  24h Change {sortIndicator('change24h')}
+                </Button>
+              </TableHead>
+              <TableHead>
+                <Button variant="ghost" onClick={() => handleSort('volume24h')}>
+                  Volume {sortIndicator('volume24h')}
+                </Button>
+              </TableHead>
+              <TableHead>
+                <Button variant="ghost" onClick={() => handleSort('marketCap')}>
+                  Market Cap {sortIndicator('marketCap')}
+                </Button>
+              </TableHead>
+              <TableHead>Spark</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {list.map((a) => (
+              <TableRow
+                key={a.id}
+                onClick={() => router.push(`/asset/${a.id}`)}
+                className="cursor-pointer hover:bg-blue-50"
+              >
+                <TableCell>{a.rank}</TableCell>
+                <TableCell>
+                  <div className="flex flex-col">
+                    <span className="font-medium">{a.name}</span>
+                    <span className="text-xs text-gray-500">{a.symbol}</span>
+                  </div>
+                </TableCell>
+                <TableCell>${a.price.toFixed(2)}</TableCell>
+                <TableCell className={a.change24h >= 0 ? 'text-green-600' : 'text-red-600'}>
+                  {a.change24h >= 0 ? '+' : ''}{a.change24h.toFixed(2)}%
+                </TableCell>
+                <TableCell>{a.volume24h.toLocaleString()}</TableCell>
+                <TableCell>{a.marketCap.toLocaleString()}</TableCell>
+                <TableCell>
+                  <Sparkline data={a.spark ?? []} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/app/components/Sparkline.tsx
+++ b/apps/web/app/components/Sparkline.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import * as React from 'react';
+
+interface SparklineProps {
+  data: number[];
+  width?: number;
+  height?: number;
+  stroke?: string;
+  fill?: string;
+}
+
+// Renders a very small SVG line chart. Scaling math keeps the tiny graph
+// representative regardless of the input range.
+export default function Sparkline({
+  data,
+  width = 100,
+  height = 24,
+  stroke = '#2563eb',
+  fill,
+}: SparklineProps) {
+  // Guard against empty data arrays. When no points are supplied, render a blank
+  // SVG at the intended size so the surrounding layout retains its spacing.
+  if (!data.length) return <svg width={width} height={height} />;
+
+  // Determine min/max to scale values into the SVG's height
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const range = max - min || 1; // avoid divide-by-zero
+  const step = width / (data.length - 1);
+
+  // Convert each data point into x/y coordinates
+  const points = data.map((v, i) => {
+    const x = i * step;
+    const y = height - ((v - min) / range) * height;
+    return `${x},${y}`;
+  });
+
+  // Build the SVG path string. "M" moves to the first point then "L" lines to the rest.
+  const path = `M${points.join(' L')}`;
+
+  // Optional area fill closes the path to the bottom of the chart
+  const area = fill ? `${path} L ${width},${height} L 0,${height} Z` : undefined;
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} width={width} height={height}>
+      {fill && <path d={area} fill={fill} opacity={0.2} />}
+      <path d={path} stroke={stroke} strokeWidth={1} fill="none" />
+    </svg>
+  );
+}

--- a/apps/web/app/components/__tests__/MarketTable.test.tsx
+++ b/apps/web/app/components/__tests__/MarketTable.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within, act, cleanup } from '@testing-library/react';
+import type { Asset } from '@stanpi/data';
+import MarketTable from '../MarketTable';
+
+// Mock next/router to capture navigation
+const push = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}));
+
+// Reusable mock asset list with edge cases:
+// - rank on third asset is a string to trigger the string sort fallback
+// - third asset omits the spark property to ensure missing data is handled
+const assets: Asset[] = [
+  {
+    id: '1',
+    name: 'Alpha',
+    symbol: 'ALP',
+    rank: 1,
+    price: 2,
+    change24h: 1,
+    volume24h: 20,
+    marketCap: 200,
+    spark: [1, 2, 3],
+  },
+  {
+    id: '2',
+    name: 'Beta',
+    symbol: 'BET',
+    rank: 2,
+    price: 3,
+    change24h: -2,
+    volume24h: 10,
+    marketCap: 100,
+    spark: [1, 1, 1],
+  },
+  {
+    id: '3',
+    name: 'Gamma',
+    symbol: 'gam',
+    rank: 'z' as any,
+    price: 1,
+    change24h: 0,
+    volume24h: 30,
+    marketCap: 300,
+    // spark intentionally missing
+  },
+];
+
+function bodyNames() {
+  return screen
+    .getAllByRole('row')
+    .slice(1)
+    .map((row) => within(row).getByText(/Alpha|Beta|Gamma/).textContent);
+}
+
+beforeEach(() => {
+  push.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe('MarketTable', () => {
+  it('renders an empty table when no assets are provided', () => {
+    render(<MarketTable assets={[]} />);
+    expect(screen.getAllByRole('row')).toHaveLength(1);
+  });
+
+  it('renders a single asset row with all columns and navigates on click', () => {
+    render(<MarketTable assets={[assets[0]]} />);
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(2);
+    const cells = within(rows[1]).getAllByRole('cell');
+    expect(cells[0].textContent).toBe('1');
+    expect(within(cells[1]).getByText('Alpha')).toBeTruthy();
+    expect(within(cells[1]).getByText('ALP')).toBeTruthy();
+    expect(cells[2].textContent).toBe('$2.00');
+    expect(cells[3].textContent).toBe('+1.00%');
+    expect(cells[4].textContent).toBe('20');
+    expect(cells[5].textContent).toBe('200');
+    expect(cells[6].querySelector('svg')).toBeTruthy();
+    fireEvent.click(rows[1]);
+    expect(push).toHaveBeenCalledWith('/asset/1');
+  });
+
+  it('filters by name and symbol case-insensitively', async () => {
+    vi.useFakeTimers();
+    render(<MarketTable assets={assets} />);
+    const input = screen.getByPlaceholderText(/search assets/i);
+
+    // Filter by name
+    fireEvent.change(input, { target: { value: 'gamma' } });
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(bodyNames()).toEqual(['Gamma']);
+
+    // Filter by symbol (case insensitive)
+    fireEvent.change(input, { target: { value: 'bet' } });
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+    });
+    expect(bodyNames()).toEqual(['Beta']);
+  });
+
+  it('debounces search input ~250ms', async () => {
+    vi.useFakeTimers();
+    render(<MarketTable assets={assets} />);
+    const input = screen.getByPlaceholderText(/search assets/i);
+    fireEvent.change(input, { target: { value: 'alp' } });
+    expect(bodyNames().length).toBe(3); // immediate list unchanged
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(bodyNames().length).toBe(3); // still unchanged before debounce
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+    });
+    expect(bodyNames()).toEqual(['Alpha']);
+  });
+
+  it('sorts numeric columns and toggles direction', () => {
+    render(<MarketTable assets={assets} />);
+    const click = (label: RegExp) =>
+      fireEvent.click(screen.getByRole('button', { name: label }));
+
+    click(/price/i);
+    expect(bodyNames()).toEqual(['Gamma', 'Alpha', 'Beta']);
+    click(/price/i);
+    expect(bodyNames()).toEqual(['Beta', 'Alpha', 'Gamma']);
+
+    click(/24h change/i);
+    expect(bodyNames()).toEqual(['Beta', 'Gamma', 'Alpha']);
+    click(/24h change/i);
+    expect(bodyNames()).toEqual(['Alpha', 'Gamma', 'Beta']);
+
+    click(/volume/i);
+    expect(bodyNames()).toEqual(['Beta', 'Alpha', 'Gamma']);
+    click(/volume/i);
+    expect(bodyNames()).toEqual(['Gamma', 'Alpha', 'Beta']);
+
+    click(/market cap/i);
+    expect(bodyNames()).toEqual(['Beta', 'Alpha', 'Gamma']);
+    click(/market cap/i);
+    expect(bodyNames()).toEqual(['Gamma', 'Alpha', 'Beta']);
+  });
+
+  it('falls back to string comparison for non-numeric values', () => {
+    render(<MarketTable assets={assets} />);
+    fireEvent.click(screen.getByRole('button', { name: /rank/i }));
+    expect(bodyNames()[0]).toBe('Gamma'); // string rank sorts last asc, first desc
+  });
+
+  it('navigates to the asset page when a row is clicked', () => {
+    render(<MarketTable assets={assets} />);
+    const row = screen.getByText('Alpha').closest('tr');
+    if (!row) throw new Error('row not found');
+    fireEvent.click(row);
+    expect(push).toHaveBeenCalledWith('/asset/1');
+  });
+});

--- a/apps/web/app/components/__tests__/Sparkline.test.tsx
+++ b/apps/web/app/components/__tests__/Sparkline.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import Sparkline from '../Sparkline';
+
+describe('Sparkline', () => {
+  it('renders a blank SVG of the given size when data is empty', () => {
+    const { container } = render(<Sparkline data={[]} width={120} height={30} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute('width')).toBe('120');
+    expect(svg?.getAttribute('height')).toBe('30');
+    expect(svg?.querySelector('path')).toBeNull();
+  });
+
+  it('renders a flat path for constant data', () => {
+    const { container } = render(<Sparkline data={[1, 1, 1]} />);
+    const path = container.querySelector('path');
+    expect(path?.getAttribute('d')).toBe('M0,24 L50,24 L100,24');
+  });
+
+  it('maps values to the correct SVG coordinates', () => {
+    const { container } = render(<Sparkline data={[0, 5, 10]} />);
+    const path = container.querySelector('path');
+    expect(path?.getAttribute('d')).toBe('M0,24 L50,12 L100,0');
+  });
+
+  it('renders an area fill when the fill prop is provided', () => {
+    const { container } = render(<Sparkline data={[0, 10]} fill="#f00" />);
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBe(2);
+    const area = paths[0];
+    expect(area.getAttribute('fill')).toBe('#f00');
+    expect(area.getAttribute('opacity')).toBe('0.2');
+  });
+});

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,25 +1,13 @@
-// Temporary homepage demo. Remove when MarketTable arrives.
+import MarketTable from './components/MarketTable';
 import { provider } from '../lib/data';
 
+// Server component that fetches asset data and renders the market table
 export default async function Page() {
   const assets = await provider.listAssets();
   return (
     <main className="p-4">
-      <h1 className="text-2xl font-bold">StanPi</h1>
-      {/* Demo list of mock assets - replace with MarketTable */}
-      <ul className="mt-4 space-y-2">
-        {assets.slice(0, 10).map((a) => (
-          <li
-            key={a.id}
-            className="flex justify-between border-b border-gray-200 pb-1 text-sm"
-          >
-            <span>
-              {a.name} ({a.symbol})
-            </span>
-            <span>${a.price.toFixed(2)}</span>
-          </li>
-        ))}
-      </ul>
+      <h1 className="mb-4 text-3xl font-semibold text-pink-700">StanPi</h1>
+      <MarketTable assets={assets} />
     </main>
   );
 }

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@stanpi/ui';
+
+// Basic button styles with variant and size options
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none',
+  {
+    variants: {
+      variant: {
+        default: 'bg-blue-500 text-white hover:bg-blue-600',
+        ghost: 'hover:bg-blue-50',
+      },
+      size: {
+        default: 'h-8 px-3',
+        sm: 'h-7 px-2',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+);
+Button.displayName = 'Button';
+
+export default Button;

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { cn } from '@stanpi/ui';
+
+// Simple card container with pastel background and border
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function Card({ className, ...props }: CardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-lg border bg-white/70 p-2 shadow-sm backdrop-blur',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export default Card;

--- a/apps/web/components/ui/input.tsx
+++ b/apps/web/components/ui/input.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from 'react';
+import { cn } from '@stanpi/ui';
+
+// Styled text input used for search fields and forms
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={cn(
+        'flex h-9 w-full rounded-md border border-gray-300 bg-white/60 px-3 py-1 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Input.displayName = 'Input';
+
+export { Input };
+export default Input;

--- a/apps/web/components/ui/table.tsx
+++ b/apps/web/components/ui/table.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { cn } from '@stanpi/ui';
+
+// Collection of table primitives matching shadcn/ui's API
+export const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <table
+    ref={ref}
+    className={cn('w-full caption-bottom text-sm', className)}
+    {...props}
+  />
+));
+Table.displayName = 'Table';
+
+export const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
+
+export const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn('[&_tr:last-child]:border-0', className)}
+    {...props}
+  />
+));
+TableBody.displayName = 'TableBody';
+
+export const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr ref={ref} className={cn('border-b transition-colors', className)} {...props} />
+));
+TableRow.displayName = 'TableRow';
+
+export const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn('px-2 py-1 text-left align-middle font-medium', className)}
+    {...props}
+  />
+));
+TableHead.displayName = 'TableHead';
+
+export const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn('px-2 py-1 align-middle', className)}
+    {...props}
+  />
+));
+TableCell.displayName = 'TableCell';

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.0",
@@ -21,9 +22,13 @@
     "@types/node": "^20.5.7",
     "@types/react": "^18.2.24",
     "autoprefixer": "^10.4.16",
+    "jsdom": "^23.0.1",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.3",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "vitest": "^1.2.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.5"
   }
 }

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,8 +1,10 @@
-/** @type {import('postcss-load-config').Config} */
-// PostCSS config hooking Tailwind and autoprefixer into Next.js build pipeline
-module.exports = {
+/**
+ * PostCSS configuration hooking Tailwind and autoprefixer into the build.
+ * Using ESM export so it works with the project's "type": "module".
+ */
+export default {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {}
-  }
+    autoprefixer: {},
+  },
 };

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,11 +2,7 @@
   // TypeScript configuration for the Next.js app
   "compilerOptions": {
     "target": "esnext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,11 +15,13 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@stanpi/data": ["../../packages/data/src"],
+      "@stanpi/ui": ["../../packages/ui/src"]
+    }
   },
   "include": [
     "next-env.d.ts",
@@ -31,7 +29,5 @@
     "**/*.tsx",
     ".next/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+      '@stanpi/ui': path.resolve(__dirname, '../../packages/ui/src'),
+      '@stanpi/data': path.resolve(__dirname, '../../packages/data/src'),
+    },
+  },
+  esbuild: {
+    jsx: 'automatic',
+  },
+});

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,0 +1,5 @@
+import { expect } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+
+// Extend Vitest's expect with jest-dom matchers for DOM assertions
+expect.extend(matchers);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "pnpm --filter web build",
     "start": "pnpm --filter web start",
     "lint": "pnpm --filter web lint",
-    "typecheck": "pnpm --filter web typecheck"
+    "typecheck": "pnpm --filter web typecheck",
+    "test": "pnpm --filter web test"
   },
   "devDependencies": {
     "eslint": "^8.57.0",


### PR DESCRIPTION
## Summary
- add client-side MarketTable with debounced search, sortable columns, and sparklines
- wire the home page to render the new table and link to asset detail placeholder
- include simple shadcn-style UI primitives and path aliases
- ensure MarketTable sorting handles numeric vs string values safely
- add MarketTable test suite covering search, debounce, sorting, navigation, and empty/single row cases
- document Sparkline's blank-state behavior when given no data
- add Sparkline test suite covering empty data, constant values, coordinate mapping, and fill rendering

## Testing
- `pnpm lint` *(fails: Cannot find module 'next/dist/compiled/babel/eslint-parser')*
- `pnpm typecheck` *(fails: Cannot find module 'vitest' or its corresponding type declarations)*
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68996ab29b28832da33d1921a63671d0