### PR TITLE
feat(asset): chart adapter (TV library/widget/lightweight) + mock UDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,17 @@ A web app for custom data analysis.
 - [ ] Chart page with candlesticks
 - [ ] Pluggable custom data provider
 - [ ] Deploy (Vercel)
+
+## Charts
+
+The Asset page supports three pluggable chart renderers:
+
+1. **Lightweight Charts** – default, uses our mock data provider.
+2. **TradingView Charting Library** – drop the official `charting_library/`
+   folder into `apps/web/public/` and set
+   `NEXT_PUBLIC_TV_DATAFEED_URL=/api/tv` to use the mock UDF endpoints.
+3. **TradingView Embedded Widget** – injects TradingView's own data; no custom
+   data feed.
+
+Use the selector on the asset page to switch modes. If the Charting Library
+files are missing the app falls back to the lightweight renderer.

--- a/apps/web/app/api/tv/[...path]/route.ts
+++ b/apps/web/app/api/tv/[...path]/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { provider } from "@/lib/data";
+import type { Candle } from "@stanpi/data";
+
+// Mock UDF-compatible endpoints for the TradingView library.
+// TODO: swap mock provider with real backend implementation.
+export async function GET(
+  req: Request,
+  { params }: { params: { path: string[] } }
+) {
+  const [endpoint] = params.path || [];
+  const { searchParams } = new URL(req.url);
+
+  switch (endpoint) {
+    case "time":
+      // Return server time in seconds
+      return new Response(Math.floor(Date.now() / 1000).toString());
+
+    case "search": {
+      const query = searchParams.get("query") ?? "";
+      const list = await provider.listAssets({ search: query });
+      const results = list.map((a) => ({
+        symbol: a.symbol,
+        full_name: `${a.symbol}USD`,
+        description: a.name,
+        ticker: a.symbol,
+        type: "crypto",
+        exchange: "MockX",
+      }));
+      return NextResponse.json(results);
+    }
+
+    case "symbols": {
+      const sym = searchParams.get("symbol") ?? "";
+      const list = await provider.listAssets();
+      const asset = list.find((a) => a.symbol === sym);
+      return NextResponse.json({
+        name: sym,
+        ticker: sym,
+        description: asset?.name ?? sym,
+        type: "crypto",
+        session: "24x7",
+        timezone: "Etc/UTC",
+        minmov: 1,
+        pricescale: 100,
+        has_intraday: true,
+        supported_resolutions: ["60", "240", "D", "W", "M"],
+      });
+    }
+
+    case "history": {
+      const sym = searchParams.get("symbol") ?? "";
+      const resolution = searchParams.get("resolution") ?? "D";
+      const map: Record<string, any> = {
+        "60": "1D",
+        "240": "1W",
+        D: "1M",
+        W: "1Y",
+        M: "ALL",
+      };
+      const range = map[resolution] || "1M";
+      try {
+        const candles = await provider.getHistory(sym, range as any);
+        if (!candles.length) return NextResponse.json({ s: "no_data" });
+        return NextResponse.json(toUdf(candles));
+      } catch (e) {
+        return NextResponse.json({ s: "error", errmsg: "unavailable" });
+      }
+    }
+  }
+
+  return NextResponse.json({ error: "Unknown endpoint" }, { status: 404 });
+}
+
+function toUdf(candles: Candle[]) {
+  return {
+    s: "ok",
+    t: candles.map((c) => Math.floor(c.t / 1000)),
+    o: candles.map((c) => c.o),
+    h: candles.map((c) => c.h),
+    l: candles.map((c) => c.l),
+    c: candles.map((c) => c.c),
+    // mock volume from price movement
+    v: candles.map((c) => Math.abs(c.c - c.o)),
+  };
+}

--- a/apps/web/app/asset/[id]/ChartSection.tsx
+++ b/apps/web/app/asset/[id]/ChartSection.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Candle } from "@stanpi/data";
+import Chart, { Renderer } from "@/app/components/chart/Chart";
+
+interface ChartSectionProps {
+  symbol: string;
+  candles: Candle[];
+}
+
+export default function ChartSection({ symbol, candles }: ChartSectionProps) {
+  const [renderer, setRenderer] = useState<Renderer>("lightweight");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("activeRenderer") as Renderer | null;
+    if (stored) setRenderer(stored);
+  }, []);
+
+  function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const value = e.target.value as Renderer;
+    setRenderer(value);
+    localStorage.setItem("activeRenderer", value);
+  }
+
+  return (
+    <div className="relative">
+      <div className="absolute right-0 top-0 z-10">
+        <select
+          className="border rounded p-1 text-sm"
+          value={renderer}
+          onChange={handleChange}
+        >
+          <option value="lightweight">Lightweight</option>
+          <option value="tradingview-library">TV Library</option>
+          <option value="tradingview-widget">TV Widget</option>
+        </select>
+      </div>
+      <Chart renderer={renderer} symbol={symbol} range="1M" candles={candles} />
+    </div>
+  );
+}

--- a/apps/web/app/asset/[id]/page.tsx
+++ b/apps/web/app/asset/[id]/page.tsx
@@ -1,19 +1,27 @@
 import Link from 'next/link';
+import ChartSection from './ChartSection';
+import { provider } from '@/lib/data';
 
 interface AssetPageProps {
   params: { id: string };
 }
 
-export default function AssetPage({ params }: AssetPageProps) {
+export default async function AssetPage({ params }: AssetPageProps) {
+  const { id } = params;
+  const symbol = `${id.toUpperCase()}USD`;
+  const candles = await provider.getHistory(id, '1M');
+
   return (
     <main className="p-4">
-      <h1 className="text-2xl font-semibold">{params.id}</h1>
-      <p className="mt-2">
+      <h1 className="text-2xl font-semibold">{id}</h1>
+      <div className="mt-4">
+        <ChartSection symbol={symbol} candles={candles} />
+      </div>
+      <p className="mt-4">
         <Link href="/" className="text-blue-600 underline">
           Back to markets
         </Link>
       </p>
-      {/* TODO: will render TradingView chart in a later PR */}
     </main>
   );
 }

--- a/apps/web/app/components/chart/Chart.tsx
+++ b/apps/web/app/components/chart/Chart.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from 'react';
+import type { Candle } from "@stanpi/data";
+import AdvancedChart from "./tv/AdvancedChart";
+import EmbeddedWidget from "./tv/EmbeddedWidget";
+import LWCChart from "./lwc/LWCChart";
+
+export type Renderer =
+  | "tradingview-library"
+  | "tradingview-widget"
+  | "lightweight";
+
+export interface ChartProps {
+  renderer: Renderer;
+  symbol: string;
+  range: "1D" | "1W" | "1M" | "1Y" | "ALL";
+  theme?: "light" | "dark" | "pastel";
+  /**
+   * Candle history used by the lightweight chart fallback.
+   * When switching renderers we persist the choice in localStorage
+   * (see Asset page – simple settings UI to flip renderers coming later).
+   */
+  candles?: Candle[];
+}
+
+export default function Chart({
+  renderer,
+  symbol,
+  range,
+  theme,
+  candles = [],
+}: ChartProps) {
+  const [fallback, setFallback] = useState(false);
+
+  if (fallback || renderer === "lightweight") {
+    return fallback ? (
+      <>
+        <p className="mb-2 text-sm text-red-600">TradingView library not found. Falling back to lightweight charts.</p>
+        <LWCChart candles={candles} theme={theme} />
+      </>) : (
+        <LWCChart candles={candles} theme={theme} />
+      );
+  }
+
+  if (renderer === "tradingview-widget") {
+    return <EmbeddedWidget symbol={symbol} theme={theme} />;
+  }
+
+  if (renderer === "tradingview-library") {
+    return (
+      <AdvancedChart
+        symbol={symbol}
+        range={range}
+        theme={theme}
+        onUnavailable={() => setFallback(true)}
+      />
+    );
+  }
+
+  return null;
+}

--- a/apps/web/app/components/chart/lwc/LWCChart.tsx
+++ b/apps/web/app/components/chart/lwc/LWCChart.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { createChart, ColorType, UTCTimestamp } from "lightweight-charts";
+import type { Candle } from "@stanpi/data";
+import { themeColors } from "@/lib/chart";
+
+interface LWCChartProps {
+  candles: Candle[];
+  theme?: "light" | "dark" | "pastel";
+}
+
+/**
+ * Mode C – Lightweight Charts (default).
+ * Renders candlesticks with a volume histogram and a simple 20 period SMA.
+ */
+export default function LWCChart({ candles, theme }: LWCChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const colors = themeColors(theme);
+    const chart = createChart(containerRef.current, {
+      layout: {
+        background: { type: ColorType.Solid, color: colors.background },
+        textColor: colors.text,
+      },
+      width: containerRef.current.clientWidth,
+      height: 400,
+    });
+
+    const candleSeries = chart.addCandlestickSeries({
+      upColor: colors.up,
+      borderUpColor: colors.up,
+      wickUpColor: colors.up,
+      downColor: colors.down,
+      borderDownColor: colors.down,
+      wickDownColor: colors.down,
+    });
+    candleSeries.setData(
+      candles.map((c) => ({
+        time: (c.t / 1000) as UTCTimestamp,
+        open: c.o,
+        high: c.h,
+        low: c.l,
+        close: c.c,
+      }))
+    );
+
+    const volumeSeries = chart.addHistogramSeries({
+      priceFormat: { type: "volume" },
+      priceScaleId: "",
+      color: colors.volumeUp,
+    });
+    volumeSeries.setData(
+      candles.map((c) => ({
+        time: (c.t / 1000) as UTCTimestamp,
+        value: Math.abs(c.c - c.o),
+        color: c.c >= c.o ? colors.volumeUp : colors.volumeDown,
+      }))
+    );
+
+    // Simple moving average with period 20
+    const smaSeries = chart.addLineSeries({ color: colors.accent });
+    const smaData: { time: UTCTimestamp; value: number }[] = [];
+    for (let i = 19; i < candles.length; i++) {
+      const slice = candles.slice(i - 19, i + 1);
+      const avg =
+        slice.reduce((sum, c) => sum + c.c, 0) / slice.length;
+      smaData.push({
+        time: (candles[i].t / 1000) as UTCTimestamp,
+        value: Number(avg.toFixed(2)),
+      });
+    }
+    smaSeries.setData(smaData);
+
+    chart.timeScale().fitContent();
+
+    return () => chart.remove();
+  }, [candles, theme]);
+
+  return <div ref={containerRef} className="w-full" />;
+}

--- a/apps/web/app/components/chart/tv/AdvancedChart.tsx
+++ b/apps/web/app/components/chart/tv/AdvancedChart.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { rangeToResolution } from "@/lib/chart";
+
+interface AdvancedChartProps {
+  symbol: string;
+  range: "1D" | "1W" | "1M" | "1Y" | "ALL";
+  theme?: "light" | "dark" | "pastel";
+  /** Callback fired when the TradingView library is missing. */
+  onUnavailable?: () => void;
+}
+
+/**
+ * Mode A – TradingView Charting Library.
+ *
+ * Drop the official `charting_library/` folder into `apps/web/public/` and set
+ * `NEXT_PUBLIC_TV_DATAFEED_URL=/api/tv` to feed custom data. The library is not
+ * bundled; we dynamically load it from the public folder at runtime.
+ */
+export default function AdvancedChart({
+  symbol,
+  range,
+  theme,
+  onUnavailable,
+}: AdvancedChartProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let widget: any;
+
+    async function init() {
+      try {
+        // Check that the library files exist in /public/charting_library
+        const head = await fetch(
+          "/charting_library/charting_library.js",
+          { method: "HEAD" }
+        );
+        if (!head.ok) {
+          onUnavailable?.();
+          return;
+        }
+        // Load the script dynamically if not already present
+        if (!(window as any).TradingView) {
+          await new Promise<void>((resolve, reject) => {
+            const script = document.createElement("script");
+            script.src = "/charting_library/charting_library.js";
+            script.onload = () => resolve();
+            script.onerror = reject;
+            document.body.appendChild(script);
+          });
+        }
+        const tv = (window as any).TradingView;
+        const datafeed = new (window as any).Datafeeds.UDFCompatibleDatafeed(
+          process.env.NEXT_PUBLIC_TV_DATAFEED_URL || "/api/tv"
+        );
+        widget = new tv.widget({
+          container_id: ref.current!,
+          symbol,
+          interval: rangeToResolution(range),
+          datafeed,
+          library_path: "/charting_library/",
+          theme: theme === "dark" ? "dark" : "light",
+          autosize: true,
+          studies: ["Volume@tv-basicstudies"],
+          overrides: { "paneProperties.crossHairMode": 1 },
+          time_frames: [
+            { text: "1D", resolution: "60", description: "1 Day" },
+            { text: "1W", resolution: "240", description: "1 Week" },
+            { text: "1M", resolution: "D", description: "1 Month" },
+            { text: "1Y", resolution: "W", description: "1 Year" },
+            { text: "ALL", resolution: "M", description: "All" },
+          ],
+        });
+      } catch (err) {
+        onUnavailable?.();
+      }
+    }
+
+    init();
+    return () => widget?.remove?.();
+  }, [symbol, range, theme, onUnavailable]);
+  return <div ref={ref} className="h-96 w-full" />;
+}

--- a/apps/web/app/components/chart/tv/EmbeddedWidget.tsx
+++ b/apps/web/app/components/chart/tv/EmbeddedWidget.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface EmbeddedWidgetProps {
+  symbol: string;
+  theme?: "light" | "dark" | "pastel";
+}
+
+/**
+ * Mode B – TradingView embedded widget.
+ *
+ * This injects TradingView's own script which displays their data directly.
+ * It does **not** use our custom data feed.
+ */
+export default function EmbeddedWidget({ symbol, theme }: EmbeddedWidgetProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    // Clear previous chart when switching symbols/themes
+    ref.current.innerHTML = "";
+
+    const script = document.createElement("script");
+    script.src = "https://s3.tradingview.com/tv.js";
+    script.async = true;
+    script.onload = () => {
+      new (window as any).TradingView.widget({
+        symbol,
+        container_id: ref.current!,
+        autosize: true,
+        theme: theme === "dark" ? "dark" : "light",
+      });
+    };
+    ref.current.appendChild(script);
+  }, [symbol, theme]);
+
+  return <div ref={ref} className="h-96 w-full" />;
+}

--- a/apps/web/lib/chart.ts
+++ b/apps/web/lib/chart.ts
@@ -1,0 +1,52 @@
+import { pastelTheme } from "./theme";
+
+export type Range = "1D" | "1W" | "1M" | "1Y" | "ALL";
+export type Theme = "light" | "dark" | "pastel";
+
+// Map UI range values to TradingView/lightweight resolutions
+export function rangeToResolution(range: Range): string {
+  const map: Record<Range, string> = {
+    "1D": "60", // hourly candles
+    "1W": "240", // 4h
+    "1M": "D", // daily
+    "1Y": "W", // weekly
+    ALL: "M", // monthly
+  };
+  return map[range];
+}
+
+// Basic color palettes per theme for charts
+export function themeColors(theme: Theme = "light") {
+  if (theme === "dark") {
+    return {
+      background: "#000000",
+      text: "#ffffff",
+      up: "#26a69a",
+      down: "#ef5350",
+      accent: "#2962FF",
+      volumeUp: "rgba(38,166,154,0.5)",
+      volumeDown: "rgba(239,83,80,0.5)",
+    };
+  }
+  if (theme === "pastel") {
+    return {
+      background: pastelTheme.background,
+      text: pastelTheme.foreground,
+      up: "#93c5fd",
+      down: "#fda4af",
+      accent: pastelTheme.accent,
+      volumeUp: "rgba(147,197,253,0.5)",
+      volumeDown: "rgba(252,165,165,0.5)",
+    };
+  }
+  // light theme
+  return {
+    background: "#ffffff",
+    text: "#000000",
+    up: "#26a69a",
+    down: "#ef5350",
+    accent: "#2962FF",
+    volumeUp: "rgba(38,166,154,0.5)",
+    volumeDown: "rgba(239,83,80,0.5)",
+  };
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "@stanpi/ui": "workspace:*",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
+    "lightweight-charts": "^4.0.0",
     "next": "14.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
## Summary
- add pluggable Chart component with TradingView Library, TradingView widget, and lightweight charts with SMA and volume
- wire Asset page to mock candle data and persist renderer choice in localStorage
- expose mock UDF endpoints for TradingView and document chart setup

## Testing
- `pnpm lint`
- `pnpm --filter web test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689983de82fc832d97c1b0ec604e96b4